### PR TITLE
chore: use ubuntu-slim runner for lightweight jobs

### DIFF
--- a/.github/workflows/_pull-request.yaml
+++ b/.github/workflows/_pull-request.yaml
@@ -16,7 +16,7 @@ defaults:
 
 jobs:
   validate:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 5
 
     steps:

--- a/.github/workflows/create-issue.yaml
+++ b/.github/workflows/create-issue.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
     name: create issue
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6
       - uses: JasonEtco/create-an-issue@1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5 # v2


### PR DESCRIPTION
Migrate lightweight CI jobs to ubuntu-slim runner to reduce costs.

## Changes
- Migrated lightweight jobs (lint, format check, validation) to `ubuntu-slim` runner
- Docker-based jobs (`_actionlint.yaml`, `_secretlint.yaml`) remain on `ubuntu-latest` as `ubuntu-slim` doesn't support Docker

## Note
Actionlint doesn't support `ubuntu-slim` runner yet (see https://github.com/rhysd/actionlint/pull/585), so actionlint checks may fail until the upstream is updated.

Refs: https://github.blog/changelog/2025-10-28-1-vcpu-linux-runner-now-available-in-github-actions-in-public-preview/

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves PR title validation and scheduled issue creation workflows from ubuntu-latest to ubuntu-slim.
> 
> - **CI workflows**:
>   - `/.github/workflows/_pull-request.yaml`
>     - `validate` job: `runs-on` changed from `ubuntu-latest` to `ubuntu-slim`.
>   - `/.github/workflows/create-issue.yaml`
>     - `build` job: `runs-on` changed from `ubuntu-latest` to `ubuntu-slim`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7a3e06293264b336400b09a6a049ab8bb6dce21a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->