### PR TITLE
chore: add Claude Code local files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,8 @@ yarn-error.log
 
 # lefthook
 lefthook-local.yaml
+
+# Claude Code
+**/.claude/settings.local.json
+**/CLAUDE.local.md
+**/.claude/worktrees/


### PR DESCRIPTION
## Summary
- Add `**/.claude/settings.local.json`, `**/CLAUDE.local.md`, `**/.claude/worktrees/` to `.gitignore`
- Prevents Claude Code local configuration and worktree files from being committed

## Test plan
- [x] Verify the three patterns are present in `.gitignore`