### PR TITLE
chore: relocate README to profile/ for .github repo migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,0 @@
-# 🦕 Nozomi Ishii
-
-![BackGround Image](./assets/images/background.png)
-
-## 職務経歴書 | CV
-
-[日本語](./src/cv/cv-ja.md)

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,0 +1,7 @@
+# 🦕 Nozomi Ishii
+
+![BackGround Image](../assets/images/background.png)
+
+## 職務経歴書 | CV
+
+[日本語](../src/cv/cv-ja.md)


### PR DESCRIPTION
## 概要

`nozomiishii/nozomiishii` → `nozomiishii/.github` へのリネームに備えた事前準備 PR（フェーズ 1）。

`.github` リポジトリでは profile README の render source が `<name>/.github/profile/README.md` になるため、先に `profile/` ディレクトリ配下へ移動しておく。

refs #723

## 変更内容

- `README.md` → `profile/README.md` に移動
- 相対パスを親ディレクトリ参照に更新:
  - `./assets/images/background.png` → `../assets/images/background.png`
  - `./src/cv/cv-ja.md` → `../src/cv/cv-ja.md`

## マージ後の想定挙動

- リネーム前: `username/username` パターンで root README を参照するルールだが、本 PR で root README を削除したため **プロフィール README は一時的に非表示になる**（判断 Q1-B を選択）
- その後フェーズ 2（GitHub 上でリポジトリをリネーム）を実施すると `profile/README.md` が自動で render される想定

## 検証観点

- [ ] マージ後、GitHub 上で `profile/README.md` が存在することを確認
- [ ] フェーズ 2（リネーム）完了後、`github.com/nozomiishii` のプロフィール README に `# 🦕 Nozomi Ishii` が表示されることを確認
- [ ] 背景画像（`../assets/images/background.png`）が表示されること
- [ ] CV リンク（`../src/cv/cv-ja.md`）が機能すること

## 後続フェーズ（別 PR 予定）

- フェーズ 2: GitHub 上でのリネーム実行（手動 UI 操作）
- フェーズ 4: community health files（CODE_OF_CONDUCT / CONTRIBUTING / SECURITY）の追加検討
- フェーズ 5: 外部参照更新（`projects.json`, `nozomiishii.code-workspace`, dotfiles）

## 実証された前提（調査結果）

公式ドキュメントには未記載だが、GitHub UI 上で `.github` repo 作成時に「profile directory に README を置け」と案内文が表示される。個人 User 所有 + `profile/README.md` で実際にプロフィールに render される実例（`rmcvxzz/.github`）も確認済み。
