### PR TITLE
fix: use absolute URLs in profile README to bypass GitHub renderer bug

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,7 +1,7 @@
 # 🦕 Nozomi Ishii
 
-![BackGround Image](../assets/images/background.png)
+![BackGround Image](https://raw.githubusercontent.com/nozomiishii/.github/main/assets/images/background.png)
 
 ## 職務経歴書 | CV
 
-[日本語](../src/cv/cv-ja.md)
+[日本語](https://github.com/nozomiishii/.github/blob/main/src/cv/cv-ja.md)


### PR DESCRIPTION
## 概要

リネーム後、プロフィールページで背景画像と CV リンクが壊れていたため、絶対 URL に書き換えて修正。

refs #723

## 原因

GitHub の profile README renderer は `.github/profile/README.md` の相対パス `../` を解決する際に **ブランチ名 segment (`main`) を欠落させる** 挙動が確認された。

rendered（壊れた例）:
```
<img src="/nozomiishii/.github/raw/assets/images/background.png">
<a href="/nozomiishii/.github/blob/src/cv/cv-ja.md">
```

正しい形:
```
/nozomiishii/.github/raw/main/assets/images/background.png
/nozomiishii/.github/blob/main/src/cv/cv-ja.md
```

## 対応

絶対 URL に置き換えて renderer の相対パス解決を回避:

- 画像: `https://raw.githubusercontent.com/nozomiishii/.github/main/assets/images/background.png`
- CV: `https://github.com/nozomiishii/.github/blob/main/src/cv/cv-ja.md`

絶対 URL は直接アクセスで `200` を返すことを確認済み。

## 検証観点

- [ ] マージ後、`github.com/nozomiishii` プロフィールページで背景画像が表示されること
- [ ] CV リンクをクリックして `cv-ja.md` に遷移できること

## トレードオフ

絶対 URL のため、将来さらに repo 名を変える場合はハードコードを更新する必要がある。個人アカウントではそう頻繁に起きないため許容範囲と判断。
