### PR TITLE
chore(workflows): fix zizmor findings in caller workflows

### DIFF
--- a/.github/workflows/_github-actions.yaml
+++ b/.github/workflows/_github-actions.yaml
@@ -12,9 +12,9 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: read
-  pull-requests: read
-  actions: read
+  contents: read  # required by actions/checkout to fetch repository code
+  pull-requests: read  # required by dorny/paths-filter to list PR files via the GitHub API
+  actions: read  # required by gh api referenced_workflows to resolve the zizmor config SHA
 
 jobs:
   github-actions:

--- a/.github/workflows/_pull-request.yaml
+++ b/.github/workflows/_pull-request.yaml
@@ -8,7 +8,7 @@ on:
       - synchronize
 
 permissions:
-  pull-requests: read
+  pull-requests: read  # required by action-semantic-pull-request to read the PR title via the GitHub API
 
 jobs:
   pull-request:

--- a/.github/workflows/create-issue.yaml
+++ b/.github/workflows/create-issue.yaml
@@ -4,12 +4,23 @@ on:
   schedule:
     - cron: '0 0 1 1,4,7,10 *'
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions: {}
+
 jobs:
   build:
     name: create issue
     runs-on: ubuntu-slim
+    permissions:
+      contents: read  # required by actions/checkout and create-an-issue to read the template file
+      issues: write  # required by JasonEtco/create-an-issue to create the issue
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: JasonEtco/create-an-issue@1b14a70e4d8dc185e5cc76d3bec9eab20257b2c5 # v2.9.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Migration PR (#736) に stacked。zizmor auditor persona の finding を全部解消する。

## Fixes

- **`_github-actions.yaml` / `_pull-request.yaml`**: 各 `permissions:` に justification コメントを追加（`undocumented-permissions`）
- **`create-issue.yaml`**:
  - workflow top-level `permissions: {}` を追加（`excessive-permissions`）
  - job-level `permissions:` で必要最小（`contents: read` + `issues: write`）を明示
  - `actions/checkout` に `persist-credentials: false` を追加（`artipacked`）
  - `concurrency:` block を追加（`concurrency-limits`）

## Test plan

- [ ] `github-actions / required` 緑（zizmor 含む）
- [ ] `secret-scan / secretlint` 緑
- [ ] `pull-request / validate` 緑
