### PR TITLE
chore(claude): run pnpm install on session start

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "pnpm install"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- Claude Code の `SessionStart` hook で `pnpm install` を毎セッション開始時に実行する設定を `.claude/settings.json` に追加
- セッション開始時に依存関係が自動同期される

## Background

[nozomiishii/dotfiles#877](https://github.com/nozomiishii/dotfiles/pull/877) で dotfiles に入れた SessionStart hook の横展開。各リポジトリで毎回 `pnpm install` を手動実行していたのを自動化する。

## Test plan

- [ ] このリポジトリで Claude Code セッションを開き直し、SessionStart hook 経由で `pnpm install` が走ることを確認
