### PR TITLE
fix: migrate lefthook extends from index.yaml to recommended.yaml

### DIFF
--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -9,7 +9,7 @@
 #   pnpx lefthook run --verbose commit-msg
 #   pnpx lefthook run --verbose post-merge
 extends:
-  - ./node_modules/@nozomiishii/lefthook-config/index.yaml
+  - ./node_modules/@nozomiishii/lefthook-config/recommended.yaml
 
 pre-commit:
   parallel: true


### PR DESCRIPTION
## 概要

`@nozomiishii/lefthook-config` v1.0 で `index.yaml` が `recommended.yaml` にリネームされたが、本プロジェクトの `lefthook.yaml` は古い `index.yaml` を `extends:` に指したままになっていた。当該パスは v1 パッケージに存在しないため `extends` が解決されず、recommended preset の hook が一切走らない状態だった。

## 変更内容

- `lefthook.yaml` の `extends:` を `./node_modules/@nozomiishii/lefthook-config/index.yaml` → `./node_modules/@nozomiishii/lefthook-config/recommended.yaml` に修正

## 参考

- [nozomiishii/configs の starter.yaml](https://github.com/nozomiishii/configs/blob/main/packages/lefthook-config/starter.yaml)
- [CHANGELOG: rename index.yaml to recommended.yaml (#2155)](https://github.com/nozomiishii/configs/commit/dee24d08c1d4f85a48d30c8b7cfa0af593094ed8)
