### PR TITLE
chore: add startup hook for session sync

### DIFF
--- a/.claude/hooks/startup.sh
+++ b/.claude/hooks/startup.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+git fetch origin --quiet
+
+# HEAD が origin/main の祖先のときだけ進める（diverged branch や未コミット作業を壊さない）。
+# --ff-only で linear history を維持。lock 更新があれば post-merge hook が pnpm install を実行する。
+if git merge-base --is-ancestor HEAD origin/main 2>/dev/null; then
+  git merge --ff-only origin/main --quiet
+fi
+
+if [ ! -d node_modules ]; then
+  pnpm install
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,10 +2,11 @@
   "hooks": {
     "SessionStart": [
       {
+        "matcher": "startup",
         "hooks": [
           {
             "type": "command",
-            "command": "pnpm install"
+            "command": "bash \"$CLAUDE_PROJECT_DIR/.claude/hooks/startup.sh\""
           }
         ]
       }


### PR DESCRIPTION
## Summary
- `.claude/hooks/startup.sh` を新規追加（session 開始時の origin/main 同期 + 必要なら pnpm install）
- `.claude/settings.json` の SessionStart hook に上記スクリプトを呼ぶ entry を追加

## 背景
[nozomiishii/workspaces#34](https://github.com/nozomiishii/workspaces/issues/34) のロールアウト作業の一環。

スクリプトは dotfiles の確立済みパターンに従う:
- `--ff-only` で linear history を維持
- HEAD が origin/main の祖先のときだけ進める（既存作業を壊さない）
- `set -euo pipefail` で strict mode

post-merge hook が lock 更新時の install をカバーし、node_modules 不在時はスクリプト末尾の install がフォールバック。

## Test plan
- [x] `bash -n .claude/hooks/startup.sh`（syntax check）
- [x] `bash .claude/hooks/startup.sh` を clean な状態で実行 → exit 0
- [x] `jq '.' .claude/settings.json`（JSON valid）

refs nozomiishii/workspaces#34
