### PR TITLE
chore: add prettier --cache flag to scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "pdf:cv": "md-to-pdf src/cv/cv-ja.md",
     "pdf:pay": "md-to-pdf src/pay/pay-ja.md",
     "pdf:resume": "md-to-pdf src/resume/resume.md",
-    "prettier": "prettier . '!docs' --ignore-unknown",
+    "prettier": "prettier . '!docs' --ignore-unknown --cache",
     "setup": "./scripts/setup.sh"
   },
   "devDependencies": {


### PR DESCRIPTION
## 概要

`@nozomiishii/prettier-config` の最新 init template に合わせて、`prettier` script に `--cache` flag を追加する。

## 背景

configs リポジトリの nozomiishii/configs#2285 で `nozo-prettier-init` の生成 scripts が更新され、`--cache` を `prettier` script に集約する形になった (`format` / `format:fix` script は action のみを持つ)。既存 repo は古い init template の名残で `--cache` が無いため、手動で揃える。

## 変更

- root `package.json` の `scripts.prettier` に `--cache` を追加: `prettier . '!docs' --ignore-unknown` → `prettier . '!docs' --ignore-unknown --cache`

## 影響範囲

`pnpm prettier` / `pnpm format` / `pnpm format:fix` 実行時に `node_modules/.cache/prettier/.prettier-cache` がキャッシュとして使われ高速化される。出力結果に変化なし。

## 注記

このブランチで `pnpm format` を実行したところ、既存 format 違反が 9 ファイル検出された (`.github/workflows/_github-actions.yaml`, `.github/workflows/_pull-request.yaml`, `.github/workflows/create-issue.yaml`, `.markdownlint-cli2.cjs`, `.textlintrc.yaml`, `commitlint.config.cjs`, `lefthook.yaml`, `pnpm-workspace.yaml`, `prettier.config.ts`)。本 PR の `--cache` 追加とは独立した既存 issue のため本 PR では対応せず、別途対応要。
