### PR TITLE
chore: drop pm from pnpm minimumReleaseAge exclude

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,7 +23,6 @@ publicHoistPattern:
 minimumReleaseAgeExclude:
   - "@nozomiishii/*"
   - git-harvest
-  - pm
 
 # pinバージョンでインストールする
 savePrefix: ""


### PR DESCRIPTION
## 概要

`pnpm-workspace.yaml` の `minimumReleaseAgeExclude` から `pm` を削除する。

## 理由

`pm` (CLI ツール) は npm 上では `@nozomiishii/pm` という名前で公開されており、既に `@nozomiishii/*` グロブで除外対象に含まれている。裸の `pm` エントリは「`pm` という名前の別パッケージ」を指すだけで、どの repo の依存にもなっておらず無意味なため削除する。
